### PR TITLE
Update Branch Names in Workflows

### DIFF
--- a/.github/workflows/build-map-renderer.yml
+++ b/.github/workflows/build-map-renderer.yml
@@ -2,11 +2,11 @@
 
 on:
   push:
-    branches: [ master, staging, trying ]
+    branches: [ main, staging, trying ] # Parkstation-GitMain
   merge_group:
   pull_request:
     types: [ opened, reopened, synchronize, ready_for_review ]
-    branches: [ master ]
+    branches: [ main ] # Parkstation-GitMain
 
 jobs:
   build:

--- a/.github/workflows/build-test-debug.yml
+++ b/.github/workflows/build-test-debug.yml
@@ -2,11 +2,11 @@ name: Build & Test Debug
 
 on:
   push:
-    branches: [ master, staging, trying ]
+    branches: [ main, staging, trying ] # Parkstation-GitMain
   merge_group:
   pull_request:
     types: [ opened, reopened, synchronize, ready_for_review ]
-    branches: [ master ]
+    branches: [ main ] # Parkstation-GitMain
 
 jobs:
   build:

--- a/.github/workflows/conflict-labeler.yml
+++ b/.github/workflows/conflict-labeler.yml
@@ -3,7 +3,7 @@ name: Check Merge Conflicts
 on:
   push:
     branches:
-      - master
+      - main # Parkstation-GitMain
   pull_request_target:
 
 jobs:

--- a/.github/workflows/test-packaging.yml
+++ b/.github/workflows/test-packaging.yml
@@ -2,7 +2,7 @@
 
 on:
   push:
-    branches: [ master, staging, trying ]
+    branches: [ main, staging, trying ] # Parkstation-GitMain
     paths:
       - '**.cs'
       - '**.csproj'
@@ -16,7 +16,7 @@ on:
   merge_group:
   pull_request:
     types: [ opened, reopened, synchronize, ready_for_review ]
-    branches: [ master ]
+    branches: [ main ] # Parkstation-GitMain
     paths:
       - '**.cs'
       - '**.csproj'

--- a/.github/workflows/update-credits.yml
+++ b/.github/workflows/update-credits.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3.6.0
         with:
-          ref: master
+          ref: main # Parkstation-GitMain
 
       - name: Get this week's Contributors
         shell: pwsh

--- a/.github/workflows/validate-rgas.yml
+++ b/.github/workflows/validate-rgas.yml
@@ -1,7 +1,7 @@
 name: RGA schema validator
 on:
   push:
-    branches: [ master, staging, trying ]
+    branches: [ main, staging, trying ] # Parkstation-GitMain
   merge_group:
   pull_request:
     types: [ opened, reopened, synchronize, ready_for_review ]

--- a/.github/workflows/validate_mapfiles.yml
+++ b/.github/workflows/validate_mapfiles.yml
@@ -1,7 +1,7 @@
 name: Map file schema validator
 on:
   push:
-    branches: [ master, staging, trying ]
+    branches: [ main, staging, trying ] # Parkstation-GitMain
   merge_group:
   pull_request:
     types: [ opened, reopened, synchronize, ready_for_review ]

--- a/.github/workflows/yaml-linter.yml
+++ b/.github/workflows/yaml-linter.yml
@@ -2,7 +2,7 @@ name: YAML Linter
 
 on:
   push:
-    branches: [ master, staging, trying ]
+    branches: [ main, staging, trying ] # Parkstation-GitMain
   merge_group:
   pull_request:
     types: [ opened, reopened, synchronize, ready_for_review ]


### PR DESCRIPTION
We're using the `main` branch instead of `master` for some reason.