### PR TITLE
Split Tests and Integration Tests Scripts

### DIFF
--- a/Scripts/bat/runTests.bat
+++ b/Scripts/bat/runTests.bat
@@ -1,0 +1,11 @@
+cd ..\..\
+
+dotnet restore
+dotnet build --configuration DebugOpt --no-restore /p:WarningsAsErrors=nullable /m
+
+mkdir Scripts\logs
+
+del Scripts\logs\Content.Tests.log
+dotnet test --no-build --configuration DebugOpt Content.Tests/Content.Tests.csproj -- NUnit.ConsoleOut=0 > Scripts\logs\Content.Tests.log
+
+pause

--- a/Scripts/bat/runTestsIntegration.bat
+++ b/Scripts/bat/runTestsIntegration.bat
@@ -5,9 +5,6 @@ dotnet build --configuration DebugOpt --no-restore /p:WarningsAsErrors=nullable 
 
 mkdir Scripts\logs
 
-del Scripts\logs\Content.Tests.log
-dotnet test --no-build --configuration DebugOpt Content.Tests/Content.Tests.csproj -- NUnit.ConsoleOut=0 > Scripts\logs\Content.Tests.log
-
 del Scripts\logs\Content.IntegrationTests.log
 dotnet test --no-build --configuration DebugOpt Content.IntegrationTests/Content.IntegrationTests.csproj -- NUnit.ConsoleOut=0 NUnit.MapWarningTo=Failed > Scripts\logs\Content.IntegrationTests.log
 

--- a/Scripts/bat/runTestsYAML.bat
+++ b/Scripts/bat/runTestsYAML.bat
@@ -4,6 +4,7 @@ dotnet restore
 dotnet build --configuration DebugOpt --no-restore /p:WarningsAsErrors=nullable /m
 
 mkdir Scripts\logs
+
 del Scripts\logs\Content.YAMLLinter.log
 dotnet run --project Content.YAMLLinter/Content.YAMLLinter.csproj --no-build -- NUnit.ConsoleOut=0 > Scripts\logs\Content.YAMLLinter.log
 

--- a/Scripts/sh/runTests.sh
+++ b/Scripts/sh/runTests.sh
@@ -5,8 +5,8 @@ dotnet build --configuration DebugOpt --no-restore /p:WarningsAsErrors=nullable 
 
 mkdir Scripts/logs
 
-rm Scripts/logs/Content.YAMLLinter.log
-dotnet run --project Content.YAMLLinter/Content.YAMLLinter.csproj --no-build -- NUnit.ConsoleOut=0 > Scripts/logs/Content.YAMLLinter.log
+rm Scripts/logs/Content.Tests.log
+dotnet test --no-build --configuration DebugOpt Content.Tests/Content.Tests.csproj -- NUnit.ConsoleOut=0 > Scripts/logs/Content.Tests.log
 
 echo "Tests complete. Press enter to continue."
 read

--- a/Scripts/sh/runTestsIntegration.sh
+++ b/Scripts/sh/runTestsIntegration.sh
@@ -5,9 +5,6 @@ dotnet build --configuration DebugOpt --no-restore /p:WarningsAsErrors=nullable 
 
 mkdir Scripts/logs
 
-rm Scripts/logs/Content.Tests.log
-dotnet test --no-build --configuration DebugOpt Content.Tests/Content.Tests.csproj -- NUnit.ConsoleOut=0 > Scripts/logs/Content.Tests.log
-
 rm Scripts/logs/Content.IntegrationTests.log
 dotnet test --no-build --configuration DebugOpt Content.IntegrationTests/Content.IntegrationTests.csproj -- NUnit.ConsoleOut=0 NUnit.MapWarningTo=Failed > Scripts/logs/Content.IntegrationTests.log
 


### PR DESCRIPTION
I was annoyed having to go through Content.Tests to test errors with Content.IntegrationTests