### PR TITLE
Port over end of round stats

### DIFF
--- a/Content.Server/Body/Systems/BloodstreamSystem.cs
+++ b/Content.Server/Body/Systems/BloodstreamSystem.cs
@@ -21,6 +21,7 @@ using Content.Shared.Speech.EntitySystems;
 using Robust.Server.Audio;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Random;
+using Content.Server.SimpleStation14.EndOfRoundStats.BloodLost;
 
 namespace Content.Server.Body.Systems;
 
@@ -92,6 +93,8 @@ public sealed class BloodstreamSystem : EntitySystem
     {
         base.Update(frameTime);
 
+        var totalBloodLost = 0f; // Parkstation-EndOfRoundStats
+
         var query = EntityQueryEnumerator<BloodstreamComponent>();
         while (query.MoveNext(out var uid, out var bloodstream))
         {
@@ -119,6 +122,8 @@ public sealed class BloodstreamSystem : EntitySystem
                 TryModifyBloodLevel(uid, (-bloodstream.BleedAmount), bloodstream);
                 // Bleed rate is reduced by the bleed reduction amount in the bloodstream component.
                 TryModifyBleedAmount(uid, -bloodstream.BleedReductionAmount, bloodstream);
+
+                totalBloodLost += bloodstream.BleedAmount / 20; // Parkstation-EndOfRoundStats
             }
 
             // deal bloodloss damage if their blood level is below a threshold.
@@ -151,6 +156,8 @@ public sealed class BloodstreamSystem : EntitySystem
                 bloodstream.StatusTime = 0;
             }
         }
+
+        RaiseLocalEvent(new BloodLostStatEvent(totalBloodLost)); // Parkstation-EndOfRoundStats
     }
 
     private void OnComponentInit(Entity<BloodstreamComponent> entity, ref ComponentInit args)

--- a/Content.Server/Fluids/EntitySystems/AbsorbentSystem.cs
+++ b/Content.Server/Fluids/EntitySystems/AbsorbentSystem.cs
@@ -1,5 +1,6 @@
 using Content.Server.Chemistry.Containers.EntitySystems;
 using Content.Server.Popups;
+using Content.Server.SimpleStation14.EndOfRoundStats.MopUsed; // Parkstation-EndOfRoundStats
 using Content.Shared.Chemistry.Components;
 using Content.Shared.Chemistry.EntitySystems;
 using Content.Shared.FixedPoint;
@@ -310,6 +311,8 @@ public sealed class AbsorbentSystem : SharedAbsorbentSystem
 
         _solutionContainerSystem.AddSolution(puddle.Solution.Value, absorberSplit);
         _solutionContainerSystem.AddSolution(absorberSoln, puddleSplit);
+
+        RaiseLocalEvent(new MopUsedStatEvent(user, puddleSplit.Volume)); // Parkstation-EndOfRoundStats
 
         _audio.PlayPvs(absorber.PickupSound, target);
         if (useDelay != null)

--- a/Content.Server/Instruments/InstrumentComponent.cs
+++ b/Content.Server/Instruments/InstrumentComponent.cs
@@ -20,6 +20,10 @@ public sealed partial class InstrumentComponent : SharedInstrumentComponent
     public ICommonSession? InstrumentPlayer =>
         _entMan.GetComponentOrNull<ActivatableUIComponent>(Owner)?.CurrentSingleUser
         ?? _entMan.GetComponentOrNull<ActorComponent>(Owner)?.PlayerSession;
+
+    // Parkstation-EndOfRoundStats-Start
+    public TimeSpan? TimeStartedPlaying { get; set; }
+    // Parkstation-EndOfRoundStats-End
 }
 
 [RegisterComponent]

--- a/Content.Server/Instruments/InstrumentSystem.cs
+++ b/Content.Server/Instruments/InstrumentSystem.cs
@@ -1,3 +1,4 @@
+using Content.Server.SimpleStation14.EndOfRoundStats.Instruments; // Parkstation-EndOfRoundStats
 using Content.Server.Administration;
 using Content.Server.Interaction;
 using Content.Server.Popups;
@@ -116,6 +117,8 @@ public sealed partial class InstrumentSystem : SharedInstrumentSystem
 
         instrument.Playing = true;
         Dirty(uid, instrument);
+
+        instrument.TimeStartedPlaying = _timing.CurTime; // Parkstation-EndOfRoundStats
     }
 
     private void OnMidiStop(InstrumentStopMidiEvent msg, EntitySessionEventArgs args)
@@ -129,6 +132,18 @@ public sealed partial class InstrumentSystem : SharedInstrumentSystem
             return;
 
         Clean(uid, instrument);
+
+        // Parkstation-EndOfRoundStats-Start
+        if (instrument.TimeStartedPlaying != null && instrument.InstrumentPlayer != null)
+        {
+            var username = instrument.InstrumentPlayer.Name;
+            var entity = instrument.InstrumentPlayer.AttachedEntity;
+            var name = entity != null ? MetaData((EntityUid) entity).EntityName : "Unknown";
+
+            RaiseLocalEvent(new InstrumentPlayedStatEvent(name, (TimeSpan) (_timing.CurTime - instrument.TimeStartedPlaying), username));
+        }
+        instrument.TimeStartedPlaying = null;
+        // Parkstation-EndOfRoundStats-End
     }
 
     private void OnMidiSetMaster(InstrumentSetMasterEvent msg, EntitySessionEventArgs args)

--- a/Content.Server/SimpleStation14/EndOfRoundStats/Bloodlost/BloodLostStatEvent.cs
+++ b/Content.Server/SimpleStation14/EndOfRoundStats/Bloodlost/BloodLostStatEvent.cs
@@ -1,0 +1,11 @@
+﻿namespace Content.Server.SimpleStation14.EndOfRoundStats.BloodLost;
+
+public sealed class BloodLostStatEvent : EntityEventArgs
+{
+    public float BloodLost;
+
+    public BloodLostStatEvent(float bloodLost)
+    {
+        BloodLost = bloodLost;
+    }
+}

--- a/Content.Server/SimpleStation14/EndOfRoundStats/Bloodlost/BloodLostStatSystem.cs
+++ b/Content.Server/SimpleStation14/EndOfRoundStats/Bloodlost/BloodLostStatSystem.cs
@@ -1,0 +1,46 @@
+﻿using Content.Server.GameTicking;
+using Content.Shared.GameTicking;
+using Robust.Shared.Configuration;
+using Content.Shared.FixedPoint;
+using Content.Shared.SimpleStation14.CCvar;
+
+namespace Content.Server.SimpleStation14.EndOfRoundStats.BloodLost;
+
+public sealed class BloodLostStatSystem : EntitySystem
+{
+    [Dependency] private readonly IConfigurationManager _config = default!;
+
+    FixedPoint2 totalBloodLost = 0;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<BloodLostStatEvent>(OnBloodLost);
+
+        SubscribeLocalEvent<RoundEndTextAppendEvent>(OnRoundEnd);
+        SubscribeLocalEvent<RoundRestartCleanupEvent>(OnRoundRestart);
+    }
+
+    private void OnBloodLost(BloodLostStatEvent args)
+    {
+        totalBloodLost += args.BloodLost;
+    }
+
+    private void OnRoundEnd(RoundEndTextAppendEvent ev)
+    {
+        var line = String.Empty;
+
+        if (totalBloodLost < _config.GetCVar<float>(SimpleStationCCVars.BloodLostThreshold))
+            return;
+
+        line += $"[color=maroon]{Loc.GetString("eorstats-bloodlost-total", ("bloodLost", totalBloodLost.Int()))}[/color]";
+
+        ev.AddLine("\n" + line);
+    }
+
+    private void OnRoundRestart(RoundRestartCleanupEvent ev)
+    {
+        totalBloodLost = 0;
+    }
+}

--- a/Content.Server/SimpleStation14/EndOfRoundStats/Command/CommandStatSystem.cs
+++ b/Content.Server/SimpleStation14/EndOfRoundStats/Command/CommandStatSystem.cs
@@ -1,0 +1,30 @@
+﻿using Content.Server.GameTicking;
+using Content.Shared.GameTicking;
+
+namespace Content.Server.SimpleStation14.EndOfRoundStats.Command;
+
+public sealed class CommandStatSystem : EntitySystem
+{
+    public List<(string, string)> eorStats = new();
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<RoundEndTextAppendEvent>(OnRoundEnd);
+        SubscribeLocalEvent<RoundRestartCleanupEvent>(OnRoundRestart);
+    }
+
+    private void OnRoundEnd(RoundEndTextAppendEvent ev)
+    {
+        foreach (var (stat, color) in eorStats)
+        {
+            ev.AddLine($"[color={color}]{stat}[/color]");
+        }
+    }
+
+    private void OnRoundRestart(RoundRestartCleanupEvent ev)
+    {
+        eorStats.Clear();
+    }
+}

--- a/Content.Server/SimpleStation14/EndOfRoundStats/Command/EORStatsAddCommand.cs
+++ b/Content.Server/SimpleStation14/EndOfRoundStats/Command/EORStatsAddCommand.cs
@@ -1,0 +1,59 @@
+﻿using System.Linq;
+using Content.Server.Administration;
+using Content.Shared.Administration;
+using Content.Shared.Administration.Logs;
+using Content.Shared.Database;
+using Robust.Shared.Console;
+
+namespace Content.Server.SimpleStation14.EndOfRoundStats.Command;
+
+[AdminCommand(AdminFlags.Admin)]
+public sealed class EORStatsAddCommmand : IConsoleCommand
+{
+    [Dependency] private readonly ISharedAdminLogManager _adminLogger = default!;
+
+    public string Command => "eorstatsadd";
+    public string Description => "Adds an end of round stat to be displayed.";
+    public string Help => $"Usage: {Command} <stat> <color?>";
+
+    public void Execute(IConsoleShell shell, string argStr, string[] args)
+    {
+        var _stats = IoCManager.Resolve<IEntitySystemManager>().GetEntitySystem<CommandStatSystem>();
+
+        if (args.Length < 1 || args.Length > 2)
+        {
+            shell.WriteError("Invalid amount of arguments.");
+            return;
+        }
+
+        if (args.Length == 2 && !Color.TryFromName(args[1], out _))
+        {
+            shell.WriteError("Invalid color.");
+            return;
+        }
+
+        _stats.eorStats.Add((args[0], args.Length == 2 ? args[1] : "Green"));
+
+        shell.WriteLine($"Added {args[0]} to end of round stats.");
+
+        _adminLogger.Add(LogType.AdminMessage, LogImpact.Low,
+            $"{shell.Player!.Name} added '{args[0]}' to end of round stats.");
+    }
+
+    public CompletionResult GetCompletion(IConsoleShell shell, string[] args)
+    {
+        if (args.Length == 1)
+        {
+            return CompletionResult.FromHint("<Stat>");
+        }
+
+        if (args.Length == 2)
+        {
+            var options = Color.GetAllDefaultColors().Select(o => new CompletionOption(o.Key));
+
+            return CompletionResult.FromHintOptions(options, "<Color?>");
+        }
+
+        return CompletionResult.Empty;
+    }
+}

--- a/Content.Server/SimpleStation14/EndOfRoundStats/Command/EORStatsListCommand.cs
+++ b/Content.Server/SimpleStation14/EndOfRoundStats/Command/EORStatsListCommand.cs
@@ -1,0 +1,37 @@
+﻿using Content.Server.Administration;
+using Content.Shared.Administration;
+using Robust.Shared.Console;
+
+namespace Content.Server.SimpleStation14.EndOfRoundStats.Command;
+
+[AdminCommand(AdminFlags.Admin)]
+public sealed class EORStatsCommand : IConsoleCommand
+{
+    public string Command => "eorstatslist";
+    public string Description => "Lists the current command-added end of round stats to be displayed.";
+    public string Help => $"Usage: {Command}";
+
+    public void Execute(IConsoleShell shell, string argStr, string[] args)
+    {
+        var _stats = IoCManager.Resolve<IEntitySystemManager>().GetEntitySystem<CommandStatSystem>();
+
+        if (args.Length != 0)
+        {
+            shell.WriteError("Invalid amount of arguments.");
+            return;
+        }
+
+        if (_stats.eorStats.Count == 0)
+        {
+            shell.WriteLine("No command-added end of round stats to display.");
+            return;
+        }
+
+        shell.WriteLine("End of round stats:");
+
+        foreach (var (stat, color) in _stats.eorStats)
+        {
+            shell.WriteLine($"'{stat}' - {color}");
+        }
+    }
+}

--- a/Content.Server/SimpleStation14/EndOfRoundStats/Command/EORStatsRemoveCommand.cs
+++ b/Content.Server/SimpleStation14/EndOfRoundStats/Command/EORStatsRemoveCommand.cs
@@ -1,0 +1,72 @@
+﻿using System.Linq;
+using Content.Server.Administration;
+using Content.Shared.Administration;
+using Robust.Shared.Console;
+
+namespace Content.Server.SimpleStation14.EndOfRoundStats.Command;
+
+[AdminCommand(AdminFlags.Admin)]
+public sealed class EORStatsRemoveCommand : IConsoleCommand
+{
+    public string Command => "eorstatsremove";
+    public string Description => "Removes a previously added end of round stat. Defaults to last added stat.";
+    public string Help => $"Usage: {Command} <stat index?>";
+
+    public void Execute(IConsoleShell shell, string argStr, string[] args)
+    {
+        var _stats = IoCManager.Resolve<IEntitySystemManager>().GetEntitySystem<CommandStatSystem>();
+
+        if (args.Length > 1)
+        {
+            shell.WriteError("Invalid amount of arguments.");
+            return;
+        }
+
+        if (_stats.eorStats.Count == 0)
+        {
+            shell.WriteError("No stats to remove.");
+            return;
+        }
+
+        int index = _stats.eorStats.Count;
+
+        if (args.Length == 1)
+        {
+            if (!int.TryParse(args[0], out index))
+            {
+                shell.WriteError("Invalid index.");
+                return;
+            }
+
+            if (index < 0 || index > _stats.eorStats.Count)
+            {
+                shell.WriteError("Index out of range.");
+                return;
+            }
+        }
+
+        index--;
+
+        shell.WriteLine($"Removed '{_stats.eorStats[index].Item1}' from end of round stats.");
+
+        _stats.eorStats.RemoveAt(index);
+    }
+
+    public CompletionResult GetCompletion(IConsoleShell shell, string[] args)
+    {
+        var _stats = IoCManager.Resolve<IEntitySystemManager>().GetEntitySystem<CommandStatSystem>();
+
+        if (args.Length == 1)
+        {
+            var options = _stats.eorStats.Select(o => new CompletionOption
+                ((_stats.eorStats.LastIndexOf((o.Item1, o.Item2)) + 1).ToString(), o.Item1));
+
+            if (options.Count() == 0)
+                return CompletionResult.FromHint("No stats to remove.");
+
+            return CompletionResult.FromOptions(options);
+        }
+
+        return CompletionResult.Empty;
+    }
+}

--- a/Content.Server/SimpleStation14/EndOfRoundStats/CuffedTime/CuffedTimeStatSystem.cs
+++ b/Content.Server/SimpleStation14/EndOfRoundStats/CuffedTime/CuffedTimeStatSystem.cs
@@ -1,0 +1,117 @@
+﻿using Content.Server.GameTicking;
+using Content.Shared.Cuffs.Components;
+using Content.Shared.GameTicking;
+using Content.Shared.Mind;
+using Content.Shared.SimpleStation14.CCvar;
+using Content.Shared.SimpleStation14.EndOfRoundStats.CuffedTime;
+using Robust.Shared.Configuration;
+using Robust.Shared.Timing;
+
+namespace Content.Server.SimpleStation14.EndOfRoundStats.CuffedTime;
+
+public sealed class CuffedTimeStatSystem : EntitySystem
+{
+    [Dependency] private readonly IGameTiming _gameTiming = default!;
+    [Dependency] private readonly IConfigurationManager _config = default!;
+
+
+    Dictionary<PlayerData, TimeSpan> userPlayStats = new();
+
+    private struct PlayerData
+    {
+        public String Name;
+        public String? Username;
+    }
+
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<CuffableComponent, CuffedTimeStatEvent>(OnUncuffed);
+
+        SubscribeLocalEvent<RoundEndTextAppendEvent>(OnRoundEnd);
+        SubscribeLocalEvent<RoundRestartCleanupEvent>(OnRoundRestart);
+    }
+
+    private void OnUncuffed(EntityUid uid, CuffableComponent component, CuffedTimeStatEvent args)
+    {
+        string? username = null;
+
+        if (EntityManager.TryGetComponent<MindComponent>(uid, out var mindComponent) &&
+            mindComponent.Session != null)
+            username = mindComponent.Session.Name;
+
+        var playerData = new PlayerData
+        {
+            Name = MetaData(uid).EntityName,
+            Username = username
+        };
+
+        if (userPlayStats.ContainsKey(playerData))
+        {
+            userPlayStats[playerData] += args.Duration;
+            return;
+        }
+
+        userPlayStats.Add(playerData, args.Duration);
+    }
+
+    private void OnRoundEnd(RoundEndTextAppendEvent ev)
+    {
+        // Gather any people currently cuffed.
+        // Otherwise people cuffed on the evac shuttle will not be counted.
+        var query = EntityQueryEnumerator<CuffableComponent>();
+        while (query.MoveNext(out var uid, out var component))
+        {
+            if (component.CuffedTime != null)
+                RaiseLocalEvent(uid, new CuffedTimeStatEvent(_gameTiming.CurTime - component.CuffedTime.Value));
+        }
+
+        // Continue with normal logic.
+        var line = "[color=cadetblue]";
+
+        (PlayerData, TimeSpan) topPlayer = (new PlayerData(), TimeSpan.Zero);
+
+        foreach (var (player, amountPlayed) in userPlayStats)
+        {
+            if (amountPlayed >= topPlayer.Item2)
+                topPlayer = (player, amountPlayed);
+        }
+
+        if (topPlayer.Item2 < TimeSpan.FromMinutes(_config.GetCVar<int>(SimpleStationCCVars.CuffedTimeThreshold)))
+            return;
+        else
+            line += GenerateTopPlayer(topPlayer.Item1, topPlayer.Item2);
+
+        ev.AddLine("\n" + line + "[/color]");
+    }
+
+    private String GenerateTopPlayer(PlayerData data, TimeSpan timeCuffed)
+    {
+        var line = String.Empty;
+
+        if (data.Username != null)
+            line += Loc.GetString
+            (
+                "eorstats-cuffedtime-hasusername",
+                ("username", data.Username),
+                ("name", data.Name),
+                ("timeCuffedMinutes", Math.Round(timeCuffed.TotalMinutes))
+            );
+        else
+            line += Loc.GetString
+            (
+                "eorstats-cuffedtime-nousername",
+                ("name", data.Name),
+                ("timeCuffedMinutes", Math.Round(timeCuffed.TotalMinutes))
+            );
+
+        return line;
+    }
+
+    private void OnRoundRestart(RoundRestartCleanupEvent ev)
+    {
+        userPlayStats.Clear();
+    }
+}

--- a/Content.Server/SimpleStation14/EndOfRoundStats/EmitSound/EmitSoundStatSystem.cs
+++ b/Content.Server/SimpleStation14/EndOfRoundStats/EmitSound/EmitSoundStatSystem.cs
@@ -1,0 +1,108 @@
+﻿using System.Diagnostics.CodeAnalysis;
+using Content.Server.GameTicking;
+using Content.Shared.GameTicking;
+using Content.Shared.SimpleStation14.CCvar;
+using Content.Shared.SimpleStation14.EndOfRoundStats.EmitSound;
+using Content.Shared.Tag;
+using Robust.Shared.Configuration;
+
+namespace Content.Server.SimpleStation14.EndOfRoundStats.EmitSound;
+
+public sealed class EmitSoundStatSystem : EntitySystem
+{
+    [Dependency] private readonly TagSystem _tag = default!;
+    [Dependency] private readonly IConfigurationManager _config = default!;
+
+
+    Dictionary<SoundSources, int> soundsEmitted = new();
+
+    // This Enum must match the exact tag you're searching for.
+    // Adding a new tag to this Enum, and ensuring the localisation is set will automatically add it to the end of round stats.
+    // Local string should be in the format: eorstats-emitsound-<Enum> (e.g. eorstats-emitsound-BikeHorn)
+    // and should have a parameter of "times" (e.g. Horns were honked a total of {$times} times!)
+    private enum SoundSources
+    {
+        BikeHorn,
+        Plushie
+    }
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<EmitSoundStatEvent>(OnSoundEmitted);
+
+        SubscribeLocalEvent<RoundEndTextAppendEvent>(OnRoundEnd);
+        SubscribeLocalEvent<RoundRestartCleanupEvent>(OnRoundRestart);
+    }
+
+    private void OnSoundEmitted(EmitSoundStatEvent ev)
+    {
+        SoundSources? source = null;
+
+        foreach (var enumSource in Enum.GetValues<SoundSources>())
+        {
+            if (_tag.HasTag(ev.Emitter, enumSource.ToString()))
+            {
+                source = enumSource;
+                break;
+            }
+        }
+
+        if (source == null)
+            return;
+
+        if (soundsEmitted.ContainsKey(source.Value))
+        {
+            soundsEmitted[source.Value]++;
+            return;
+        }
+
+        soundsEmitted.Add(source.Value, 1);
+    }
+
+    private void OnRoundEnd(RoundEndTextAppendEvent ev)
+    {
+        var minCount = _config.GetCVar<int>(SimpleStationCCVars.EmitSoundThreshold);
+
+        var line = string.Empty;
+        var entry = false;
+
+        if (minCount == 0)
+            return;
+
+        foreach (var source in soundsEmitted.Keys)
+        {
+            if (soundsEmitted[source] > minCount && TryGenerateSoundsEmitted(source, soundsEmitted[source], out var lineTemp))
+            {
+                line += "\n" + lineTemp;
+
+                entry = true;
+            }
+        }
+
+        if (entry)
+            ev.AddLine("[color=springGreen]" + line + "[/color]");
+    }
+
+    private bool TryGenerateSoundsEmitted(SoundSources source, int soundsEmitted, [NotNullWhen(true)] out string? line)
+    {
+        string preLocalString = "eorstats-emitsound-" + source.ToString();
+
+        if (!Loc.TryGetString(preLocalString, out var localString, ("times", soundsEmitted)))
+        {
+            Logger.DebugS("eorstats", "Unknown messageId: {0}", preLocalString);
+            Logger.Debug("Make sure the string is following the correct format, and matches the enum! (eorstats-emitsound-<enum>)");
+
+            throw new ArgumentException("Unknown messageId: " + preLocalString);
+        }
+
+        line = localString;
+        return true;
+    }
+
+    private void OnRoundRestart(RoundRestartCleanupEvent ev)
+    {
+        soundsEmitted.Clear();
+    }
+}

--- a/Content.Server/SimpleStation14/EndOfRoundStats/InstrumentPlayed/InstrumentPlayedStatEvent.cs
+++ b/Content.Server/SimpleStation14/EndOfRoundStats/InstrumentPlayed/InstrumentPlayedStatEvent.cs
@@ -1,0 +1,15 @@
+﻿namespace Content.Server.SimpleStation14.EndOfRoundStats.Instruments;
+
+public sealed class InstrumentPlayedStatEvent : EntityEventArgs
+{
+    public String Player;
+    public TimeSpan Duration;
+    public String? Username;
+
+    public InstrumentPlayedStatEvent(String player, TimeSpan duration, String? username)
+    {
+        Player = player;
+        Duration = duration;
+        Username = username;
+    }
+}

--- a/Content.Server/SimpleStation14/EndOfRoundStats/InstrumentPlayed/InstrumentPlayedStatSystem.cs
+++ b/Content.Server/SimpleStation14/EndOfRoundStats/InstrumentPlayed/InstrumentPlayedStatSystem.cs
@@ -1,0 +1,115 @@
+﻿using System.Linq;
+using Content.Server.GameTicking;
+using Content.Server.Instruments;
+using Content.Shared.GameTicking;
+using Content.Shared.SimpleStation14.CCvar;
+using Robust.Shared.Configuration;
+using Robust.Shared.Timing;
+
+namespace Content.Server.SimpleStation14.EndOfRoundStats.Instruments;
+
+public sealed class InstrumentPlayedStatSystem : EntitySystem
+{
+    [Dependency] private readonly IGameTiming _gameTiming = default!;
+    [Dependency] private readonly IConfigurationManager _config = default!;
+
+    Dictionary<PlayerData, TimeSpan> userPlayStats = new();
+
+    private struct PlayerData
+    {
+        public String Name;
+        public String? Username;
+    }
+
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<InstrumentPlayedStatEvent>(OnInstrumentPlayed);
+
+        SubscribeLocalEvent<RoundEndTextAppendEvent>(OnRoundEnd);
+        SubscribeLocalEvent<RoundRestartCleanupEvent>(OnRoundRestart);
+    }
+
+    private void OnInstrumentPlayed(InstrumentPlayedStatEvent args)
+    {
+        var playerData = new PlayerData
+        {
+            Name = args.Player,
+            Username = args.Username
+        };
+
+        if (userPlayStats.ContainsKey(playerData))
+        {
+            userPlayStats[playerData] += args.Duration;
+            return;
+        }
+
+        userPlayStats.Add(playerData, args.Duration);
+    }
+
+    private void OnRoundEnd(RoundEndTextAppendEvent ev)
+    {
+        // Gather any people currently playing istruments.
+        // This part is very important :P
+        // Otherwise people playing their tunes on the evac shuttle will not be counted.
+        foreach (var instrument in EntityManager.EntityQuery<InstrumentComponent>().Where(i => i.InstrumentPlayer != null))
+        {
+            if (instrument.TimeStartedPlaying != null && instrument.InstrumentPlayer != null)
+            {
+                var username = instrument.InstrumentPlayer.Name;
+                var entity = instrument.InstrumentPlayer.AttachedEntity;
+                var name = entity != null ? MetaData((EntityUid) entity).EntityName : "Unknown";
+
+                RaiseLocalEvent(new InstrumentPlayedStatEvent(name, (TimeSpan) (_gameTiming.CurTime - instrument.TimeStartedPlaying), username));
+            }
+        }
+
+        // Continue with normal logic.
+        var line = "[color=springGreen]";
+
+        (PlayerData, TimeSpan) topPlayer = (new PlayerData(), TimeSpan.Zero);
+
+        foreach (var (player, amountPlayed) in userPlayStats)
+        {
+            if (amountPlayed >= topPlayer.Item2)
+                topPlayer = (player, amountPlayed);
+        }
+
+        if (topPlayer.Item2 < TimeSpan.FromMinutes(_config.GetCVar(SimpleStationCCVars.InstrumentPlayedThreshold)))
+            return;
+        else
+            line += GenerateTopPlayer(topPlayer.Item1, topPlayer.Item2);
+
+        ev.AddLine("\n" + line + "[/color]");
+    }
+
+    private String GenerateTopPlayer(PlayerData data, TimeSpan amountPlayed)
+    {
+        var line = String.Empty;
+
+        if (data.Username != null)
+            line += Loc.GetString
+            (
+                "eorstats-instrumentplayed-topplayer-hasusername",
+                ("username", data.Username),
+                ("name", data.Name),
+                ("amountPlayedMinutes", Math.Round(amountPlayed.TotalMinutes))
+            );
+        else
+            line += Loc.GetString
+            (
+                "eorstats-instrumentplayed-topplayer-hasnousername",
+                ("name", data.Name),
+                ("amountPlayedMinutes", Math.Round(amountPlayed.TotalMinutes))
+            );
+
+        return line;
+    }
+
+    private void OnRoundRestart(RoundRestartCleanupEvent ev)
+    {
+        userPlayStats.Clear();
+    }
+}

--- a/Content.Server/SimpleStation14/EndOfRoundStats/MopUsed/MopUsedStatEvent.cs
+++ b/Content.Server/SimpleStation14/EndOfRoundStats/MopUsed/MopUsedStatEvent.cs
@@ -1,0 +1,15 @@
+﻿using Content.Shared.FixedPoint;
+
+namespace Content.Server.SimpleStation14.EndOfRoundStats.MopUsed;
+
+public sealed class MopUsedStatEvent : EntityEventArgs
+{
+    public EntityUid Mopper;
+    public FixedPoint2 AmountMopped;
+
+    public MopUsedStatEvent(EntityUid mopper, FixedPoint2 amountMopped)
+    {
+        Mopper = mopper;
+        AmountMopped = amountMopped;
+    }
+}

--- a/Content.Server/SimpleStation14/EndOfRoundStats/MopUsed/MopUsedStatSystem.cs
+++ b/Content.Server/SimpleStation14/EndOfRoundStats/MopUsed/MopUsedStatSystem.cs
@@ -1,0 +1,170 @@
+﻿using System.Linq;
+using Content.Server.GameTicking;
+using Content.Server.Mind;
+using Content.Shared.FixedPoint;
+using Content.Shared.GameTicking;
+using Content.Shared.Mind;
+using Content.Shared.SimpleStation14.CCvar;
+using Robust.Shared.Configuration;
+
+namespace Content.Server.SimpleStation14.EndOfRoundStats.MopUsed;
+
+public sealed class MopUsedStatSystem : EntitySystem
+{
+    [Dependency] private readonly IConfigurationManager _config = default!;
+    [Dependency] private readonly MindSystem _mind = default!;
+
+
+    Dictionary<MopperData, FixedPoint2> userMopStats = new();
+    int timesMopped = 0;
+
+    private struct MopperData
+    {
+        public String Name;
+        public String? Username;
+    }
+
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<MopUsedStatEvent>(OnMopUsed);
+
+        SubscribeLocalEvent<RoundEndTextAppendEvent>(OnRoundEnd);
+        SubscribeLocalEvent<RoundRestartCleanupEvent>(OnRoundRestart);
+    }
+
+
+    private void OnMopUsed(MopUsedStatEvent args)
+    {
+        timesMopped++;
+
+        var name = MetaData(args.Mopper).EntityName;
+        var username = EntityManager.TryGetComponent<MindComponent>(args.Mopper, out var mindComponent) && mindComponent.Session != null ? mindComponent.Session.Name : null;
+
+        var mopperData = new MopperData
+        {
+            Name = name,
+            Username = username
+        };
+
+        if (userMopStats.ContainsKey(mopperData))
+        {
+            userMopStats[mopperData] += args.AmountMopped;
+            return;
+        }
+
+        userMopStats.Add(mopperData, args.AmountMopped);
+    }
+
+    private void OnRoundEnd(RoundEndTextAppendEvent ev)
+    {
+        var line = String.Empty;
+
+        if (userMopStats.Count == 0 && _config.GetCVar<bool>(SimpleStationCCVars.MopUsedDisplayNone))
+        {
+            line += "\n[color=red]" + Loc.GetString("eorstats-mop-noamountmopped") + "[/color]";
+        }
+        else if (userMopStats.Count == 0)
+        {
+            return;
+        }
+        else
+        {
+            var sortedMoppers = userMopStats.OrderByDescending(m => m.Value);
+
+            int totalAmountMopped = sortedMoppers.Sum(m => (int) m.Value);
+
+            String impressColor;
+
+            if (totalAmountMopped < _config.GetCVar<int>(SimpleStationCCVars.MopUsedThreshold))
+                return;
+
+            switch (totalAmountMopped)
+            {
+                case var x when x > 2600:
+                    impressColor = "royalBlue";
+                    break;
+                case var x when x > 1400:
+                    impressColor = "gold";
+                    break;
+                case var x when x > 600:
+                    impressColor = "slateBlue";
+                    break;
+                default:
+                    impressColor = "fireBrick";
+                    break;
+            }
+
+            line += "\n" + Loc.GetString("eorstats-mop-amountmopped", ("amountMopped", totalAmountMopped), ("timesMopped", timesMopped), ("impressColor", impressColor));
+
+            if (_config.GetCVar<int>(SimpleStationCCVars.MopUsedTopMopperCount) > 0)
+                line += "\n" + Loc.GetString("eorstats-mop-topmopper-header");
+
+            var currentPlace = 1;
+            foreach (var mopper in sortedMoppers)
+            {
+                if (currentPlace > _config.GetCVar<int>(SimpleStationCCVars.MopUsedTopMopperCount))
+                    break;
+
+                line += GenerateTopMopper(mopper.Key, mopper.Value, currentPlace);
+
+                currentPlace++;
+            }
+        }
+
+        ev.AddLine(line);
+    }
+
+    private String GenerateTopMopper(MopperData data, FixedPoint2 amountMopped, int place)
+    {
+        var line = String.Empty;
+
+        if (amountMopped > 0)
+        {
+            String impressColor;
+
+            switch (place)
+            {
+                case 1:
+                    impressColor = "gold";
+                    break;
+                case 2:
+                    impressColor = "slateBlue";
+                    break;
+                default:
+                    impressColor = "fireBrick";
+                    break;
+            }
+
+            if (data.Username != null)
+                line += "\n" + Loc.GetString
+                (
+                    "eorstats-mop-topmopper-hasusername",
+                    ("name", data.Name),
+                    ("username", data.Username),
+                    ("amountMopped", (int) amountMopped),
+                    ("impressColor", impressColor),
+                    ("place", place)
+                );
+            else
+                line += "\n" + Loc.GetString
+                (
+                    "eorstats-mop-topmopper-hasnousername",
+                    ("name", data.Name),
+                    ("amountMopped", (int) amountMopped),
+                    ("impressColor", impressColor),
+                    ("place", place)
+                );
+        }
+
+        return line;
+    }
+
+    private void OnRoundRestart(RoundRestartCleanupEvent ev)
+    {
+        userMopStats.Clear();
+        timesMopped = 0;
+    }
+}

--- a/Content.Server/SimpleStation14/EndOfRoundStats/ShotsFired/ShotsFiredStatSystem.cs
+++ b/Content.Server/SimpleStation14/EndOfRoundStats/ShotsFired/ShotsFiredStatSystem.cs
@@ -1,0 +1,56 @@
+﻿using Content.Server.GameTicking;
+using Content.Shared.GameTicking;
+using Content.Shared.SimpleStation14.CCvar;
+using Content.Shared.Weapons.Ranged.Components;
+using Content.Shared.Weapons.Ranged.Events;
+using Robust.Shared.Configuration;
+
+namespace Content.Server.SimpleStation14.EndOfRoundStats.ShotsFired;
+
+public sealed class ShotsFiredStatSystem : EntitySystem
+{
+    [Dependency] private readonly IConfigurationManager _config = default!;
+
+    int shotsFired = 0;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<GunComponent, AmmoShotEvent>(OnShotFired);
+
+        SubscribeLocalEvent<RoundEndTextAppendEvent>(OnRoundEnd);
+        SubscribeLocalEvent<RoundRestartCleanupEvent>(OnRoundRestart);
+    }
+
+    private void OnShotFired(EntityUid _, GunComponent __, AmmoShotEvent args)
+    {
+        shotsFired++;
+    }
+
+    private void OnRoundEnd(RoundEndTextAppendEvent ev)
+    {
+        var line = string.Empty;
+
+        line += GenerateShotsFired(shotsFired);
+
+        if (line != string.Empty)
+            ev.AddLine("\n[color=cadetblue]" + line + "[/color]");
+    }
+
+    private string GenerateShotsFired(int shotsFired)
+    {
+        if (shotsFired == 0 && _config.GetCVar<bool>(SimpleStationCCVars.ShotsFiredDisplayNone))
+            return Loc.GetString("eorstats-shotsfired-noshotsfired");
+
+        if (shotsFired == 0 || shotsFired < _config.GetCVar<int>(SimpleStationCCVars.ShotsFiredThreshold))
+            return string.Empty;
+
+        return Loc.GetString("eorstats-shotsfired-amount", ("shotsFired", shotsFired));
+    }
+
+    private void OnRoundRestart(RoundRestartCleanupEvent ev)
+    {
+        shotsFired = 0;
+    }
+}

--- a/Content.Server/SimpleStation14/EndOfRoundStats/SlippedCount/SlippedCountStatSystem.cs
+++ b/Content.Server/SimpleStation14/EndOfRoundStats/SlippedCount/SlippedCountStatSystem.cs
@@ -1,0 +1,119 @@
+﻿using System.Linq;
+using Content.Server.GameTicking;
+using Content.Shared.GameTicking;
+using Content.Shared.Mind;
+using Content.Shared.SimpleStation14.CCvar;
+using Content.Shared.Slippery;
+using Robust.Shared.Configuration;
+
+namespace Content.Server.SimpleStation14.EndOfRoundStats.SlippedCount;
+
+public sealed class SlippedCountStatSystem : EntitySystem
+{
+    [Dependency] private readonly IConfigurationManager _config = default!;
+
+    Dictionary<PlayerData, int> userSlipStats = new();
+
+    private struct PlayerData
+    {
+        public String Name;
+        public String? Username;
+    }
+
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<SlipperyComponent, SlipEvent>(OnSlip);
+
+        SubscribeLocalEvent<RoundEndTextAppendEvent>(OnRoundEnd);
+        SubscribeLocalEvent<RoundRestartCleanupEvent>(OnRoundRestart);
+    }
+
+
+    private void OnSlip(EntityUid uid, SlipperyComponent slipComp, ref SlipEvent args)
+    {
+        string? username = null;
+
+        var entity = args.Slipped;
+
+        if (EntityManager.TryGetComponent<MindComponent>(entity, out var mindComp) &&
+            mindComp.Session != null && mindComp.Session.Name != null)
+        {
+            username = mindComp.Session.Name;
+        }
+
+        var playerData = new PlayerData
+        {
+            Name = MetaData(entity).EntityName,
+            Username = username
+        };
+
+        if (userSlipStats.ContainsKey(playerData))
+        {
+            userSlipStats[playerData]++;
+            return;
+        }
+
+        userSlipStats.Add(playerData, 1);
+    }
+
+    private void OnRoundEnd(RoundEndTextAppendEvent ev)
+    {
+        var sortedSlippers = userSlipStats.OrderByDescending(m => m.Value);
+
+        int totalTimesSlipped = sortedSlippers.Sum(m => (int) m.Value);
+
+        var line = "[color=springGreen]";
+
+        if (totalTimesSlipped < _config.GetCVar(SimpleStationCCVars.SlippedCountThreshold))
+        {
+            if (totalTimesSlipped == 0 && _config.GetCVar(SimpleStationCCVars.SlippedCountDisplayNone))
+            {
+                line += Loc.GetString("eorstats-slippedcount-none");
+            }
+            else
+                return;
+        }
+        else
+        {
+            line += Loc.GetString("eorstats-slippedcount-totalslips", ("timesSlipped", totalTimesSlipped));
+
+            line += GenerateTopSlipper(sortedSlippers.First().Key, sortedSlippers.First().Value);
+        }
+
+        ev.AddLine("\n" + line + "[/color]");
+    }
+
+    private String GenerateTopSlipper(PlayerData data, int amountSlipped)
+    {
+        var line = String.Empty;
+
+        if (_config.GetCVar(SimpleStationCCVars.SlippedCountTopSlipper) == false)
+            return line;
+
+        if (data.Username != null)
+            line += Loc.GetString
+            (
+                "eorstats-slippedcount-topslipper-hasusername",
+                ("username", data.Username),
+                ("name", data.Name),
+                ("slipcount", amountSlipped)
+            );
+        else
+            line += Loc.GetString
+            (
+                "eorstats-slippedcount-topslipper-hasnousername",
+                ("name", data.Name),
+                ("slipcount", amountSlipped)
+            );
+
+        return "\n" + line;
+    }
+
+    private void OnRoundRestart(RoundRestartCleanupEvent ev)
+    {
+        userSlipStats.Clear();
+    }
+}

--- a/Content.Shared/Cuffs/Components/CuffableComponent.cs
+++ b/Content.Shared/Cuffs/Components/CuffableComponent.cs
@@ -39,6 +39,15 @@ public sealed partial class CuffableComponent : Component
     /// </summary>
     [DataField("canStillInteract"), ViewVariables(VVAccess.ReadWrite)]
     public bool CanStillInteract = true;
+
+    // Parkstation-EndOfRoundStats-Start
+    /// <summary>
+    ///     When this entity was cuffed, if currently cuffed.
+    ///     Used for end of round stats.
+    /// </summary>
+    [DataField("cuffedTime")]
+    public TimeSpan? CuffedTime { get; set; }
+    // Parkstation-EndOfRoundStats-End
 }
 
 [Serializable, NetSerializable]

--- a/Content.Shared/SimpleStation14/CCvar/CCVars.cs
+++ b/Content.Shared/SimpleStation14/CCvar/CCVars.cs
@@ -1,0 +1,122 @@
+﻿using Robust.Shared.Configuration;
+
+namespace Content.Shared.SimpleStation14.CCvar;
+
+[CVarDefs]
+public sealed class SimpleStationCCVars
+{
+    /*
+     * End of round stats
+     */
+    #region EndOfRoundStats
+    #region BloodLost
+    /// <summary>
+    ///     The amount of blood lost required to trigger the BloodLost end of round stat.
+    /// </summary>
+    /// <remarks>
+    ///     Setting this to 0 will disable the BloodLost end of round stat.
+    /// </remarks>
+    public static readonly CVarDef<float> BloodLostThreshold =
+        CVarDef.Create("eorstats.bloodlost_threshold", 300f, CVar.SERVERONLY);
+    #endregion
+
+    #region CuffedTime
+    /// <summary>
+    ///     The amount of time required to trigger the CuffedTime end of round stat, in minutes.
+    /// </summary>
+    /// <remarks>
+    ///     Setting this to 0 will disable the CuffedTime end of round stat.
+    /// </remarks>
+    public static readonly CVarDef<int> CuffedTimeThreshold =
+        CVarDef.Create("eorstats.cuffedtime_threshold", 8, CVar.SERVERONLY);
+    #endregion
+
+    #region EmitSound
+    /// <summary>
+    ///     The amount of sounds required to trigger the EmitSound end of round stat.
+    /// </summary>
+    /// <remarks>
+    ///     Setting this to 0 will disable the EmitSound end of round stat.
+    /// </remarks>
+    public static readonly CVarDef<int> EmitSoundThreshold =
+        CVarDef.Create("eorstats.emitsound_threshold", 80, CVar.SERVERONLY);
+    #endregion
+
+    #region InstrumentPlayed
+    /// <summary>
+    ///     The amount of instruments required to trigger the InstrumentPlayed end of round stat, in minutes.
+    /// </summary>
+    /// <remarks>
+    ///     Setting this to 0 will disable the InstrumentPlayed end of round stat.
+    /// </remarks>
+    public static readonly CVarDef<int> InstrumentPlayedThreshold =
+        CVarDef.Create("eorstats.instrumentplayed_threshold", 8, CVar.SERVERONLY);
+    #endregion
+
+    #region MopUsed
+    /// <summary>
+    ///     The amount of liquid mopped required to trigger the MopUsed end of round stat.
+    /// </summary>
+    /// <remarks>
+    ///     Setting this to 0 will disable the MopUsed end of round stat.
+    /// </remarks>
+    public static readonly CVarDef<int> MopUsedThreshold =
+        CVarDef.Create("eorstats.mopused_threshold", 200, CVar.SERVERONLY);
+
+    /// <summary>
+    ///     Should a stat be displayed specifically when no mopping was done?
+    /// </summary>
+    public static readonly CVarDef<bool> MopUsedDisplayNone =
+        CVarDef.Create("eorstats.mopused_displaynone", true, CVar.SERVERONLY);
+
+    /// <summary>
+    ///     The amount of top moppers to show in the end of round stats.
+    /// </summary>
+    /// <remarks>
+    ///     Setting this to 0 will disable the top moppers.
+    /// </remarks>
+    public static readonly CVarDef<int> MopUsedTopMopperCount =
+        CVarDef.Create("eorstats.mopused_topmoppercount", 3, CVar.SERVERONLY);
+    #endregion
+
+    #region ShotsFired
+    /// <summary>
+    ///     The amount of shots fired required to trigger the ShotsFired end of round stat.
+    /// </summary>
+    /// <remarks>
+    ///     Setting this to 0 will disable the ShotsFired end of round stat.
+    /// </remarks>
+    public static readonly CVarDef<int> ShotsFiredThreshold =
+        CVarDef.Create("eorstats.shotsfired_threshold", 40, CVar.SERVERONLY);
+
+    /// <summary>
+    ///     Should a stat be displayed specifically when no shots were fired?
+    /// </summary>
+    public static readonly CVarDef<bool> ShotsFiredDisplayNone =
+        CVarDef.Create("eorstats.shotsfired_displaynone", true, CVar.SERVERONLY);
+    #endregion
+
+    #region SlippedCount
+    /// <summary>
+    ///     The amount of times slipped required to trigger the SlippedCount end of round stat.
+    /// </summary>
+    /// <remarks>
+    ///     Setting this to 0 will disable the SlippedCount end of round stat.
+    /// </remarks>
+    public static readonly CVarDef<int> SlippedCountThreshold =
+        CVarDef.Create("eorstats.slippedcount_threshold", 30, CVar.SERVERONLY);
+
+    /// <summary>
+    ///     Should a stat be displayed specifically when nobody was done?
+    /// </summary>
+    public static readonly CVarDef<bool> SlippedCountDisplayNone =
+        CVarDef.Create("eorstats.slippedcount_displaynone", true, CVar.SERVERONLY);
+
+    /// <summary>
+    ///     Should the top slipper be displayed in the end of round stats?
+    /// </summary>
+    public static readonly CVarDef<bool> SlippedCountTopSlipper =
+        CVarDef.Create("eorstats.slippedcount_topslipper", true, CVar.SERVERONLY);
+    #endregion
+    #endregion
+}

--- a/Content.Shared/SimpleStation14/EndOfRoundStats/CuffedTime/CuffedTimeStatEvent.cs
+++ b/Content.Shared/SimpleStation14/EndOfRoundStats/CuffedTime/CuffedTimeStatEvent.cs
@@ -1,0 +1,11 @@
+﻿namespace Content.Shared.SimpleStation14.EndOfRoundStats.CuffedTime; // Handcuffs are shared.
+
+public sealed class CuffedTimeStatEvent : EntityEventArgs
+{
+    public TimeSpan Duration;
+
+    public CuffedTimeStatEvent(TimeSpan duration)
+    {
+        Duration = duration;
+    }
+}

--- a/Content.Shared/SimpleStation14/EndOfRoundStats/EmitSound/EmitSoundStatEvent.cs
+++ b/Content.Shared/SimpleStation14/EndOfRoundStats/EmitSound/EmitSoundStatEvent.cs
@@ -1,0 +1,15 @@
+﻿using Robust.Shared.Audio;
+
+namespace Content.Shared.SimpleStation14.EndOfRoundStats.EmitSound; // Sound emitters are shared.
+
+public sealed class EmitSoundStatEvent : EntityEventArgs
+{
+    public EntityUid Emitter;
+    public SoundSpecifier Sound;
+
+    public EmitSoundStatEvent(EntityUid emitter, SoundSpecifier sound)
+    {
+        Emitter = emitter;
+        Sound = sound;
+    }
+}

--- a/Content.Shared/Sound/SharedEmitSoundSystem.cs
+++ b/Content.Shared/Sound/SharedEmitSoundSystem.cs
@@ -3,6 +3,7 @@ using Content.Shared.Interaction;
 using Content.Shared.Interaction.Events;
 using Content.Shared.Maps;
 using Content.Shared.Popups;
+using Content.Shared.SimpleStation14.EndOfRoundStats.EmitSound; // Parkstation-EndOfRoundStats
 using Content.Shared.Sound.Components;
 using Content.Shared.Throwing;
 using JetBrains.Annotations;
@@ -117,6 +118,11 @@ public abstract class SharedEmitSoundSystem : EntitySystem
             // don't predict sounds that client couldn't have played already
             _audioSystem.PlayPvs(component.Sound, uid);
         }
+
+        // Parkstation-EndOfRoundStats-Start
+        if (_netMan.IsServer)
+            RaiseLocalEvent(new EmitSoundStatEvent(component.Owner, component.Sound));
+        // Parkstation-EndOfRoundStats-End
     }
 
     private void OnEmitSoundUnpaused(EntityUid uid, EmitSoundOnCollideComponent component, ref EntityUnpausedEvent args)

--- a/Resources/Locale/en-US/simplestation14/Content/RoundEndStats/bloodLostStats.ftl
+++ b/Resources/Locale/en-US/simplestation14/Content/RoundEndStats/bloodLostStats.ftl
@@ -1,0 +1,1 @@
+eorstats-bloodlost-total = {$bloodLost} units of blood were lost this round!

--- a/Resources/Locale/en-US/simplestation14/Content/RoundEndStats/cuffedTimeStats.ftl
+++ b/Resources/Locale/en-US/simplestation14/Content/RoundEndStats/cuffedTimeStats.ftl
@@ -1,0 +1,2 @@
+eorstats-cuffedtime-hasusername = {$username} as {$name} spent {$timeCuffedMinutes} minutes in cuffs this round! What'd they do??
+eorstats-cuffedtime-hasnousername = {$name} spent {$timeCuffedMinutes} minutes in cuffs this round! What'd they do??

--- a/Resources/Locale/en-US/simplestation14/Content/RoundEndStats/emitSoundStats.ftl
+++ b/Resources/Locale/en-US/simplestation14/Content/RoundEndStats/emitSoundStats.ftl
@@ -1,0 +1,4 @@
+# Make sure the strings all follow the same format, and end with the respective enum. They're selected automatically.
+
+eorstats-emitsound-BikeHorn = Horns were honked a total of {$times} times!
+eorstats-emitsound-Plushie = Plushies were squeezed {$times} times this shift!

--- a/Resources/Locale/en-US/simplestation14/Content/RoundEndStats/instrumentPlayedStats.ftl
+++ b/Resources/Locale/en-US/simplestation14/Content/RoundEndStats/instrumentPlayedStats.ftl
@@ -1,0 +1,2 @@
+eorstats-instrumentplayed-topplayer-hasusername = The master of vibes this round was {$username} as {$name} having played their tunes for {$amountPlayedMinutes} minutes!
+eorstats-instrumentplayed-topplayer-hasnousername =  The master of vibes this round was {$name} having played their tunes for {$amountPlayedMinutes} minutes!

--- a/Resources/Locale/en-US/simplestation14/Content/RoundEndStats/mopUsedStats.ftl
+++ b/Resources/Locale/en-US/simplestation14/Content/RoundEndStats/mopUsedStats.ftl
@@ -1,0 +1,8 @@
+eorstats-mop-amountmopped = A total of [color={$impressColor}]{$amountMopped}[/color] units of liquid was mopped this round across [color={$impressColor}]{$timesMopped}[/color] puddles!
+
+eorstats-mop-topmopper-header = The top moppers were:
+
+eorstats-mop-topmopper-hasusername = [color={$impressColor}]{$place}. {$username} as {$name} with {$amountMopped} units mopped![/color]
+eorstats-mop-topmopper-hasnousername = [color={$impressColor}]{$place}. {$name} with {$amountMopped} units mopped![/color]
+
+eorstats-mop-noamountmopped = Not one puddle was mopped this round!

--- a/Resources/Locale/en-US/simplestation14/Content/RoundEndStats/shotsFiredStats.ftl
+++ b/Resources/Locale/en-US/simplestation14/Content/RoundEndStats/shotsFiredStats.ftl
@@ -1,0 +1,2 @@
+eorstats-shotsfired-noshotsfired = Not one shot was fired this round!
+eorstats-shotsfired-amount = {$shotsFired} shots were fired this round.

--- a/Resources/Locale/en-US/simplestation14/Content/RoundEndStats/slippedCountStats.ftl
+++ b/Resources/Locale/en-US/simplestation14/Content/RoundEndStats/slippedCountStats.ftl
@@ -1,0 +1,6 @@
+eorstats-slippedcount-totalslips = The crew slipped a total of {$timesSlipped} times this shift!
+
+eorstats-slippedcount-none = The crew didn't slip at all this shift!
+
+eorstats-slippedcount-topslipper-hasusername = {$username} as {$name} was a clutz this shift and slipped {$slipcount} times!
+eorstats-slippedcount-topslipper-hasnousername = {$name} was a clutz this shift and slipped {$slipcount} times!


### PR DESCRIPTION
# Description

Ports over the Parkstation end of round stats, a list item from https://github.com/Simple-Station/Parkstation-Friendly-Chainsaw/issues/2.
From https://github.com/Simple-Station/Parkstation/pull/117 and https://github.com/Simple-Station/Parkstation/pull/217.

---

# TODO

- [ ] Add number of items dropped stat when https://github.com/Simple-Station/Parkstation-Friendly-Chainsaw/pull/54 is merged
- [ ] Test and make sure up-to-date code

---

# Changelog

<!-- You can add an author after the `:cl:` to change the name that appears in the changelog, ex: `:cl: Death`, it will default to your GitHub display name -->

:cl:
- add: Added back the interesting end-of-round stats
