### PR TITLE
Scale Material Sprites Down

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Materials/Sheets/glass.yml
+++ b/Resources/Prototypes/Entities/Objects/Materials/Sheets/glass.yml
@@ -7,6 +7,7 @@
   components:
   - type: Sprite
     sprite: Objects/Materials/Sheets/glass.rsi
+    scale: 0.65, 0.65 # Parkstation-SmallerMaterials
   - type: Item
     sprite: Objects/Materials/Sheets/glass.rsi
     size: Normal
@@ -47,7 +48,7 @@
         acts: [ "Destruction" ]
   - type: SolutionContainerManager
     solutions:
-      glass: 
+      glass:
         canReact: false
 
 - type: entity
@@ -197,7 +198,7 @@
         - ReagentId: Carbon
           Quantity: 0.5
         canReact: false
-        
+
 - type: entity
   parent: SheetGlassBase
   id: SheetPGlass
@@ -443,8 +444,8 @@
           Quantity: 4.5
         - ReagentId: Carbon
           Quantity: 0.5
-        canReact: false 
-    
+        canReact: false
+
 - type: entity
   parent: SheetRUGlass
   id: SheetRUGlass1

--- a/Resources/Prototypes/Entities/Objects/Materials/Sheets/glass.yml
+++ b/Resources/Prototypes/Entities/Objects/Materials/Sheets/glass.yml
@@ -48,7 +48,7 @@
         acts: [ "Destruction" ]
   - type: SolutionContainerManager
     solutions:
-      glass:
+      glass: 
         canReact: false
 
 - type: entity
@@ -198,7 +198,7 @@
         - ReagentId: Carbon
           Quantity: 0.5
         canReact: false
-
+        
 - type: entity
   parent: SheetGlassBase
   id: SheetPGlass
@@ -444,8 +444,8 @@
           Quantity: 4.5
         - ReagentId: Carbon
           Quantity: 0.5
-        canReact: false
-
+        canReact: false 
+    
 - type: entity
   parent: SheetRUGlass
   id: SheetRUGlass1

--- a/Resources/Prototypes/Entities/Objects/Materials/Sheets/metal.yml
+++ b/Resources/Prototypes/Entities/Objects/Materials/Sheets/metal.yml
@@ -6,6 +6,7 @@
   components:
   - type: Sprite
     sprite: Objects/Materials/Sheets/metal.rsi
+    scale: 0.65, 0.65 # Parkstation-SmallerMaterials
   - type: Item
     sprite: Objects/Materials/Sheets/metal.rsi
     size: Normal

--- a/Resources/Prototypes/Entities/Objects/Materials/Sheets/other.yml
+++ b/Resources/Prototypes/Entities/Objects/Materials/Sheets/other.yml
@@ -6,6 +6,7 @@
   components:
   - type: Sprite
     sprite: Objects/Materials/Sheets/other.rsi
+    scale: 0.65, 0.65 # Parkstation-SmallerMaterials
   - type: Item
     sprite: Objects/Materials/Sheets/other.rsi
     size: Normal

--- a/Resources/Prototypes/Entities/Objects/Materials/crystal_shard.yml
+++ b/Resources/Prototypes/Entities/Objects/Materials/crystal_shard.yml
@@ -11,6 +11,7 @@
       - sprite: Objects/Materials/Shards/crystal.rsi
         state: shard1
         map: [ "enum.DamageStateVisualLayers.Base" ]
+    scale: 0.65, 0.65 # Parkstation-SmallerMaterials
   - type: RandomSprite
     available:
       - enum.DamageStateVisualLayers.Base:

--- a/Resources/Prototypes/Entities/Objects/Materials/ingots.yml
+++ b/Resources/Prototypes/Entities/Objects/Materials/ingots.yml
@@ -60,7 +60,7 @@
         reagents:
         - ReagentId: Gold
           Quantity: 10
-
+          
 - type: entity
   parent: IngotGold
   id: IngotGold1

--- a/Resources/Prototypes/Entities/Objects/Materials/ingots.yml
+++ b/Resources/Prototypes/Entities/Objects/Materials/ingots.yml
@@ -6,6 +6,7 @@
   components:
   - type: Sprite
     sprite: Objects/Materials/ingots.rsi
+    scale: 0.65, 0.65 # Parkstation-SmallerMaterials
   - type: Item
     sprite: Objects/Materials/ingots.rsi
     size: Normal
@@ -59,7 +60,7 @@
         reagents:
         - ReagentId: Gold
           Quantity: 10
-          
+
 - type: entity
   parent: IngotGold
   id: IngotGold1

--- a/Resources/Prototypes/Entities/Objects/Materials/materials.yml
+++ b/Resources/Prototypes/Entities/Objects/Materials/materials.yml
@@ -6,6 +6,7 @@
   components:
   - type: Sprite
     sprite: Objects/Materials/materials.rsi
+    scale: 0.65, 0.65 # Parkstation-SmallerMaterials
   - type: Item
     sprite: Objects/Materials/materials.rsi
     size: Normal
@@ -177,6 +178,7 @@
     layers:
     - state: durathread_3
       map: ["base"]
+    scale: 1, 1 # Parkstation-SmallerMaterials - Durathread looks fine normally
   - type: Appearance
   - type: Construction
     graph: Durathread
@@ -285,6 +287,7 @@
     sprite: /Textures/Objects/Misc/monkeycube.rsi
     state: cube
     color: "#8A9A5B"
+    scale: 1, 1 # Parkstation-SmallerMaterials - Biomass looks fine normally
   - type: GuideHelp
     guides:
     - Cloning

--- a/Resources/Prototypes/Entities/Objects/Materials/parts.yml
+++ b/Resources/Prototypes/Entities/Objects/Materials/parts.yml
@@ -6,6 +6,7 @@
   - type: Sprite
     sprite: Objects/Materials/parts.rsi
     state: rods
+    scale: 0.65, 0.65 # Parkstation-SmallerMaterials
   - type: Item
     sprite: Objects/Materials/parts.rsi
   - type: Tag

--- a/Resources/Prototypes/Entities/Objects/Materials/shards.yml
+++ b/Resources/Prototypes/Entities/Objects/Materials/shards.yml
@@ -10,6 +10,7 @@
       - sprite: Objects/Materials/Shards/shard.rsi
         state: shard1
         map: [ "enum.DamageStateVisualLayers.Base" ]
+    scale: 0.65, 0.65 # Parkstation-SmallerMaterials
   - type: RandomSprite
     available:
       - enum.DamageStateVisualLayers.Base:

--- a/Resources/Prototypes/Nyanotrasen/Entities/Objects/Materials/materials.yml
+++ b/Resources/Prototypes/Nyanotrasen/Entities/Objects/Materials/materials.yml
@@ -9,6 +9,7 @@
     layers:
       - state: bluespace_3
         map: ["base"]
+    scale: 1, 1 # Parkstation-SmallerMaterials - Bluespace looks fine normally
   - type: Appearance
   - type: Material
   - type: PhysicalComposition
@@ -51,6 +52,7 @@
   - type: Sprite
     sprite: Nyanotrasen/Objects/Materials/mothroach.rsi
     state: mothroachhide
+    scale: 0.65, 0.65 # Parkstation-SmallerMaterials
   - type: Tag
     tags:
       - MothroachHide


### PR DESCRIPTION
<details><summary><h1>Media</h1></summary>
<p>

![Content Client_iv0Rbwy5xC](https://github.com/Simple-Station/Parkstation-Friendly-Chainsaw/assets/77995199/c7ef5a43-2e0e-4f2b-b20a-1455d6494f82)

</p>
</details>

---

# Changelog

:cl:
- tweak: Material sprites are no longer very large
